### PR TITLE
[Breaking] Rename the runner file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The idea behind this plugin-tool is that you don't have to hard code the instruc
 
 The most important thing you need to remember is that this plugin-tool depends on a file with the information of the targets: The runner file.
 
-The runner file is called `.woopackrunner` and it's created when you build your targets, on your project root directory. You should probably add it to your `.gitignore`.
+The runner file is called `woopackrunner.json` and it's created when you build your targets, on your project root directory. You should probably add it to your `.gitignore`.
 
 If the feature to copy project files is enabled, the file will be automatically copied to the distribution directory when the files are copied; otherwise, you'll have to copy it manually before moving the distribution directory to the production environment (deploying).
 

--- a/src/services/runner/file.js
+++ b/src/services/runner/file.js
@@ -24,7 +24,7 @@ class RunnerFile {
      * The name of the runner file.
      * @type {string}
      */
-    this.filename = '.woopackrunner';
+    this.filename = 'woopackrunner.json';
     /**
      * The path to the runner file.
      * @type {string}

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -124,7 +124,7 @@ describe('app:WoopackRunner', () => {
 
   it('should copy runner file when Woopack copies the project files', () => {
     // Given
-    const runnerFileName = '.woopackrunner';
+    const runnerFileName = 'woopackrunner.json';
     const getRunnerFileName = jest.fn(() => runnerFileName);
     const get = jest.fn(() => ({
       listen: () => {},

--- a/tests/services/runner/file.test.js
+++ b/tests/services/runner/file.test.js
@@ -28,7 +28,7 @@ describe('services/runner:runnerFile', () => {
       join: jest.fn((rest) => rest),
     };
     let sut = null;
-    const expectedFilename = '.woopackrunner';
+    const expectedFilename = 'woopackrunner.json';
     const expectedFileTemplate = {
       runnerVersion: info.version,
       version: 'development',
@@ -60,7 +60,7 @@ describe('services/runner:runnerFile', () => {
     let sut = null;
     let defaultName = null;
     let nameAfterChange = null;
-    const expectedDefaultFilename = '.woopackrunner';
+    const expectedDefaultFilename = 'woopackrunner.json';
     // When
     sut = new RunnerFile(asPlugin, info, pathUtils);
     defaultName = sut.getFilename();


### PR DESCRIPTION
### What does this PR do?

Since the name started with `.`, it was being ignored on a few production environments of projects I tried to migrate to woopack.

I know this is not the best solution, that will come soon when I make the name configurable, but it works for now.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```